### PR TITLE
Add license to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "jshint": "./node_modules/.bin/jshint `npm run -s files`"
   },
   "main": "finally.js",
+  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/matthew-andrews/Promise.prototype.finally"


### PR DESCRIPTION
Add a license to package.json so that automatic license checkers can
quickly determine the license of the package. Assuming MIT based on the
comment at the bottom of the README.md file.